### PR TITLE
Fix bug with Line chart when data is an object

### DIFF
--- a/src/Line.js
+++ b/src/Line.js
@@ -309,7 +309,7 @@ class Line {
       .attr('pointer-events', 'all');
 
     this.dataSources.map((key, idx) => {
-      const points = this.data.map((d, i) => {
+      const points = this.data[key].map((d, i) => {
         return this.x === undefined ?
           [this.xScale(i), this.yScale(d[key])] :
           [this.xScale(this.x[i]), this.yScale(+d[key])];


### PR DESCRIPTION
This error happened to me when using roughViz through the react wrapper. But it was fixed when i edited this line of code in roughviz itself. That's why i'm creating the PR here.

You can reproduce the error in this sandbox: https://codesandbox.io/s/react-codesandbox-wb9ew

The fix i suggested aligns with the format of data as you can see in other places in the same file. `data = { x: [1, 2] }` is supposed to be an object whose keys are in `dataSource` array