### PR TITLE
Issue 28: Do not overwrite 0 values with defaults.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
     "parser": "babel-eslint",
     "env": {
         "browser": true,
+        "jest": true,
         "node": true
     },
     "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 dist/
 node_modules
-tests/
 jest.config.js
 examples/
 .cache

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "d3-array": "^2.3.1",
     "d3-axis": "^1.0.12",
     "d3-fetch": "^1.1.2",
-    "d3-scale": "^3.2.0",
     "d3-format": "^1.4.1",
     "d3-scale": "^3.2.0",
     "d3-scale-chromatic": "^1.5.0",
     "d3-selection": "^1.4.0",
     "d3-shape": "^1.3.5",
+    "lodash.get": "^4.4.2",
     "roughjs": "^3.1.0"
   },
   "devDependencies": {

--- a/src/Bar.js
+++ b/src/Bar.js
@@ -6,12 +6,8 @@ import { format } from 'd3-format';
 import { scaleBand, scaleLinear } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import rough from 'roughjs/dist/rough.umd';
-
-const roughCeiling = (roughness) => {
-  let roughVal = roughness > 20 ? 20 : roughness;
-  return roughVal;
-};
-
+import get from 'lodash.get';
+import { roughCeiling } from './utils/roughCeiling';
 
 class Bar {
   constructor(opts) {
@@ -19,34 +15,34 @@ class Bar {
     this.el = opts.element;
     this.data = opts.data;
     this.element = opts.element;
-    this.margin = opts.margin || {top: 50, right: 20, bottom: 70, left: 100};
+    this.margin = opts.margin || { top: 50, right: 20, bottom: 70, left: 100 };
     this.title = opts.title;
-    this.color = opts.color || 'skyblue';
-    this.highlight = opts.highlight || 'coral';
-    this.roughness = roughCeiling(opts.roughness) || 1;
-    this.stroke = opts.stroke || 'black';
-    this.strokeWidth = opts.strokeWidth || 1;
-    this.axisStrokeWidth = opts.axisStrokeWidth || 0.5;
-    this.axisRoughness = opts.axisRoughness || 0.5;
-    this.innerStrokeWidth = opts.innerStrokeWidth || 1;
+    this.color = get(opts, 'color', 'skyblue');
+    this.highlight = get(opts, 'highlight', 'coral');
+    this.roughness = roughCeiling({ roughness: opts.roughness });
+    this.stroke = get(opts, 'stroke', 'black');
+    this.strokeWidth = get(opts, 'strokeWidth', 1);
+    this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.5);
+    this.axisRoughness = get(opts, 'axisRoughness', 0.5);
+    this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.fillWeight = opts.fillWeight || 0.5;
-    this.simplification = opts.simplification || 0.2;
+    this.bowing = get(opts, 'bowing', 0);
+    this.fillWeight = get(opts, 'fillWeight', 0.5);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.interactive = opts.interactive !== false;
     this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '0.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.labels = (this.dataFormat === 'object') ? 'labels' : opts.labels;
     this.values = (this.dataFormat === 'object') ? 'values' : opts.values;
     this.xValueFormat = opts.xValueFormat;
     this.yValueFormat = opts.yValueFormat;
-    this.padding = opts.padding || 0.1;
-    this.xLabel = opts.xLabel || '';
-    this.yLabel = opts.yLabel || '';
-    this.labelFontSize = opts.labelFontSize || '1rem';
+    this.padding = get(opts, 'padding', 0.1);
+    this.xLabel = get(opts, 'xLabel', '');
+    this.yLabel = get(opts, 'yLabel', '');
+    this.labelFontSize = get(opts, 'labelFontSize', '1rem');
     // new width
     this.initChartValues(opts);
     // resolve font
@@ -89,8 +85,8 @@ class Bar {
       this.fontFamily = 'gaeguregular';
     } else if (
       this.font === 1 ||
-        this.font.toString().toLowerCase() === 'indie flower'
-    ){
+      this.font.toString().toLowerCase() === 'indie flower'
+    ) {
       addFontIndieFlower(this.svg);
       this.fontFamily = 'indie_flowerregular';
     } else {

--- a/src/BarH.js
+++ b/src/BarH.js
@@ -6,47 +6,43 @@ import { format } from 'd3-format';
 import { scaleBand, scaleLinear } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import rough from 'roughjs/dist/rough.umd';
-
-const roughCeiling = (roughness) => {
-  let roughVal = roughness > 20 ? 20 : roughness;
-  return roughVal;
-};
+import get from 'lodash.get';
+import { roughCeiling } from './utils/roughCeiling';
 
 class BarH {
-
   constructor(opts) {
     // load in arguments from config object
     this.el = opts.element;
     // this.data = opts.data;
     this.element = opts.element;
-    this.margin = opts.margin || {top: 50, right: 20, bottom: 50, left: 100};
+    this.margin = opts.margin || { top: 50, right: 20, bottom: 50, left: 100 };
     this.title = opts.title;
-    this.color = opts.color || 'skyblue';
-    this.highlight = opts.highlight || 'coral';
-    this.roughness = roughCeiling(opts.roughness) || 1;
-    this.stroke = opts.stroke || 'black';
-    this.strokeWidth = opts.strokeWidth || 1;
-    this.axisStrokeWidth = opts.axisStrokeWidth || 0.5;
-    this.axisRoughness = opts.axisRoughness || 1;
-    this.innerStrokeWidth = opts.innerStrokeWidth || 1;
+    this.color = get(opts, 'color', 'skyblue');
+    this.highlight = get(opts, 'highlight', 'coral');
+    this.roughness = roughCeiling({ roughness: opts.roughness });
+    this.stroke = get(opts, 'stroke', 'black');
+    this.strokeWidth = get(opts, 'strokeWidth', 1);
+    this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.5);
+    this.axisRoughness = get(opts, 'axisRoughness', 0.5);
+    this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.fillWeight = opts.fillWeight || 0.5;
-    this.simplification = opts.simplification || 0.2;
+    this.bowing = get(opts, 'bowing', 0);
+    this.fillWeight = get(opts, 'fillWeight', 0.5);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.interactive = opts.interactive !== false;
     this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.labels = (this.dataFormat === 'object') ? 'labels' : opts.labels;
     this.values = (this.dataFormat === 'object') ? 'values' : opts.values;
     this.xValueFormat = opts.xValueFormat;
     this.yValueFormat = opts.yValueFormat;
-    this.padding = opts.padding || 0.1;
-    this.xLabel = opts.xLabel || '';
-    this.yLabel = opts.yLabel || '';
-    this.labelFontSize = opts.labelFontSize || '1rem';
+    this.padding = get(opts, 'padding', 0.1);
+    this.xLabel = get(opts, 'xLabel', '');
+    this.yLabel = get(opts, 'yLabel', '');
+    this.labelFontSize = get(opts, 'labelFontSize', '1rem');
     // new width
     this.initChartValues(opts);
     // resolve font
@@ -90,7 +86,7 @@ class BarH {
     } else if (
       this.font === 1 ||
       this.font.toString().toLowerCase() === 'indie flower'
-    ){
+    ) {
       addFontIndieFlower(this.svg);
       this.fontFamily = 'indie_flowerregular';
     } else {

--- a/src/Donut.js
+++ b/src/Donut.js
@@ -5,11 +5,8 @@ import { arc, pie } from 'd3-shape';
 import rough from 'roughjs/dist/rough.umd';
 import { colors } from './utils/colors';
 import { addLegend } from './utils/addLegend';
-
-const roughCeiling = roughness => {
-  let roughVal = roughness > 30 ? 30 : roughness;
-  return roughVal;
-};
+import { roughCeiling } from './utils/roughCeiling';
+import get from 'lodash.get';
 
 class Donut {
   constructor(opts) {
@@ -19,19 +16,19 @@ class Donut {
     this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 10, left: 20 };
     this.title = opts.title;
-    this.colors = opts.colors || colors;
+    this.colors = get(opts, 'colors', colors);
     this.highlight = opts.highlight;
-    this.roughness = roughCeiling(opts.roughness) || 1;
-    this.strokeWidth = opts.strokeWidth || 0.75;
-    this.innerStrokeWidth = opts.innerStrokeWidth || 0.75;
+    this.roughness = roughCeiling({ roughness: opts.roughness, ceiling: 30 });
+    this.strokeWidth = get(opts, 'strokeWidth', 0.75);
+    this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 0.75);
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.fillWeight = opts.fillWeight || 0.85;
-    this.simplification = opts.simplification || 0.2;
+    this.bowing = get(opts, 'bowing', 0);
+    this.fillWeight = get(opts, 'fillWeight', 0.85);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.interactive = opts.interactive !== false;
     this.titleFontSize = opts.titleFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = typeof opts.data === 'object' ? 'object' : 'file';
     this.labels = this.dataFormat === 'object' ? 'labels' : opts.labels;
     this.values = this.dataFormat === 'object' ? 'values' : opts.values;
@@ -41,7 +38,7 @@ class Donut {
       return;
     }
     this.legend = opts.legend !== false;
-    this.legendPosition = opts.legendPosition || 'right';
+    this.legendPosition = get(opts, 'legendPosition', 'right');
     // new width
     this.initChartValues(opts);
     // resolve font

--- a/src/Line.js
+++ b/src/Line.js
@@ -9,11 +9,8 @@ import { mouse, select, selectAll } from 'd3-selection';
 import { line } from 'd3-shape';
 import rough from 'roughjs/dist/rough.umd';
 import { colors } from './utils/colors';
-
-const roughCeiling = (roughness) => {
-  let roughVal = roughness > 20 ? 20 : roughness;
-  return roughVal;
-};
+import { roughCeiling } from './utils/roughCeiling';
+import get from 'lodash.get';
 
 const allDataExtent = (data) => {
   // get extend for all keys in data
@@ -29,36 +26,36 @@ class Line {
     // load in arguments from config object
     this.el = opts.element;
     this.element = opts.element;
-    this.margin = opts.margin || {top: 50, right: 20, bottom: 50, left: 100};
+    this.margin = opts.margin || { top: 50, right: 20, bottom: 50, left: 100 };
     this.title = opts.title;
-    this.roughness = roughCeiling(opts.roughness) || 2.2;
+    this.roughness = roughCeiling({ roughness: opts.roughness, defaultValue: 2.2 });
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.axisStrokeWidth = opts.axisStrokeWidth || 0.4;
-    this.axisRoughness = opts.axisRoughness || 0.9;
+    this.bowing = get(opts, 'bowing', 0);
+    this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.4);
+    this.axisRoughness = get(opts, 'axisRoughness', 0.9);
     this.interactive = opts.interactive !== false;
-    this.stroke = opts.stroke || 'black';
-    this.fillWeight = opts.fillWeight || 0.85;
-    this.simplification = opts.simplification || 0.2;
+    this.stroke = get(opts, 'stroke', 'black');
+    this.fillWeight = get(opts, 'fillWeight', 0.85);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.colors = opts.colors;
-    this.strokeWidth = opts.strokeWidth || 8;
+    this.strokeWidth = get(opts, 'strokeWidth', 8);
     this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '0.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.x = opts.x;
     this.y = (this.dataFormat === 'object') ? 'y' : opts.y;
     this.xValueFormat = opts.xValueFormat;
     this.yValueFormat = opts.yValueFormat;
     this.legend = opts.legend !== false;
-    this.legendPosition = opts.legendPosition || 'right';
+    this.legendPosition = get(opts, 'legendPosition', 'right');
     this.circle = opts.circle !== false;
-    this.circleRadius = opts.circleRadius || 10;
-    this.circleRoughness = roughCeiling(opts.circleRoughness) || 2;
-    this.xLabel = opts.xLabel || '';
-    this.yLabel = opts.yLabel || '';
-    this.labelFontSize = opts.labelFontSize || '1rem';
+    this.circleRadius = get(opts, 'circleRadius', 10);
+    this.circleRoughness = roughCeiling({ roughness: opts.circleRoughness, defaultValue: 2 });
+    this.xLabel = get(opts, 'xLabel', '');
+    this.yLabel = get(opts, 'yLabel', '');
+    this.labelFontSize = get(opts, 'labelFontSize', '1rem');
     if (this.dataFormat === 'file') {
       this.dataSources = [];
       this.yKeys = Object.keys(opts).filter((name) => /y/.test(name));
@@ -86,8 +83,8 @@ class Line {
       this.fontFamily = 'gaeguregular';
     } else if (
       this.font === 1 ||
-        this.font.toString().toLowerCase() === 'indie flower'
-    ){
+      this.font.toString().toLowerCase() === 'indie flower'
+    ) {
       addFontIndieFlower(this.svg);
       this.fontFamily = 'indie_flowerregular';
     } else {
@@ -217,15 +214,15 @@ class Line {
   addAxes() {
     const xAxis = axisBottom(this.xScale)
       .tickSize(0)
-      .tickFormat((d) => { return this.xValueFormat ?
-        format(this.xValueFormat)(d) :
-        d; });
+      .tickFormat((d) => {
+        return this.xValueFormat ? format(this.xValueFormat)(d) : d;
+      });
 
     const yAxis = axisLeft(this.yScale)
       .tickSize(0)
-      .tickFormat((d) => { return this.yValueFormat ?
-        format(this.yValueFormat)(d) :
-        d; });
+      .tickFormat((d) => {
+        return this.yValueFormat ? format(this.yValueFormat)(d) : d;
+      });
 
     // x-axis
     this.svg.append('g')

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -5,34 +5,30 @@ import { arc, pie } from 'd3-shape';
 import rough from 'roughjs/dist/rough.umd';
 import { colors } from './utils/colors';
 import { addLegend } from './utils/addLegend';
-
-const roughCeiling = (roughness) => {
-  let roughVal = roughness > 30 ? 30 : roughness;
-  return roughVal;
-};
+import { roughCeiling } from './utils/roughCeiling';
+import get from 'lodash.get';
 
 class Pie {
-
   constructor(opts) {
     // load in arguments from config object
     this.el = opts.element;
     // this.data = opts.data;
     this.element = opts.element;
-    this.margin = opts.margin || {top: 50, right: 20, bottom: 10, left: 20};
+    this.margin = opts.margin || { top: 50, right: 20, bottom: 10, left: 20 };
     this.title = opts.title;
-    this.colors = opts.colors || colors;
+    this.colors = get(opts, 'colors', colors);
     this.highlight = opts.highlight;
-    this.roughness = roughCeiling(opts.roughness) || 0;
-    this.strokeWidth = opts.strokeWidth || 0.75;
-    this.innerStrokeWidth = opts.innerStrokeWidth || 1;
+    this.roughness = roughCeiling({ roughness: opts.roughness, ceiling: 30, defaultValue: 0 });
+    this.strokeWidth = get(opts, 'strokeWidth', 0.75);
+    this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.fillWeight = opts.fillWeight || 0.5;
-    this.simplification = opts.simplification || 0.2;
+    this.bowing = get(opts, 'bowing', 0);
+    this.fillWeight = get(opts, 'fillWeight', 0.5);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.interactive = opts.interactive !== false;
     this.titleFontSize = opts.titleFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '0.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.labels = (this.dataFormat === 'object') ? 'labels' : opts.labels;
     this.values = (this.dataFormat === 'object') ? 'values' : opts.values;
@@ -42,7 +38,7 @@ class Pie {
       return;
     }
     this.legend = opts.legend !== false;
-    this.legendPosition = opts.legendPosition || 'right';
+    this.legendPosition = get(opts, 'legendPosition', 'right');
     // new width
     this.initChartValues(opts);
     // resolve font
@@ -87,7 +83,7 @@ class Pie {
     } else if (
       this.font === 1 ||
       this.font.toString().toLowerCase() === 'indie flower'
-    ){
+    ) {
       addFontIndieFlower(this.svg);
       this.fontFamily = 'indie_flowerregular';
     } else {

--- a/src/Scatter.js
+++ b/src/Scatter.js
@@ -3,14 +3,11 @@ import { axisBottom, axisLeft } from 'd3-axis';
 import { csv, tsv } from 'd3-fetch';
 import { format } from 'd3-format';
 import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
+import { roughCeiling } from './utils/roughCeiling';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import rough from 'roughjs/dist/rough.umd';
-
-const roughCeiling = (roughness) => {
-  let roughVal = roughness > 20 ? 20 : roughness;
-  return roughVal;
-};
+import get from 'lodash.get';
 
 const defaultColors = ['pink', 'skyblue', 'coral', 'gold', 'teal', 'grey',
   'darkgreen', 'pink', 'brown', 'slateblue', 'grey1', 'orange'];
@@ -21,37 +18,37 @@ class Scatter {
     this.el = opts.element;
     // this.data = opts.data;
     this.element = opts.element;
-    this.margin = opts.margin || {top: 50, right: 20, bottom: 50, left: 100};
+    this.margin = opts.margin || { top: 50, right: 20, bottom: 50, left: 100 };
     this.title = opts.title;
     this.colorVar = opts.colorVar;
-    this.roughness = roughCeiling(opts.roughness) || 1;
+    this.roughness = roughCeiling({ roughness: opts.roughness });
     this.highlight = opts.highlight;
-    this.highlightLabel = opts.highlightLabel || 'xy';
-    this.radius = opts.radius || 8;
+    this.highlightLabel = get(opts, 'highlightLabel', 'xy');
+    this.radius = get(opts, 'radius', 8);
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.axisStrokeWidth = opts.axisStrokeWidth || 0.4;
-    this.axisRoughness = opts.axisRoughness || 0.9;
+    this.bowing = get(opts, 'bowing', 0);
+    this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.4);
+    this.axisRoughness = get(opts, 'axisRoughness', 0.9);
     this.interactive = opts.interactive !== false;
     this.curbZero = opts.curbZero === true;
-    this.innerStrokeWidth = opts.innerStrokeWidth || 1;
-    this.stroke = opts.stroke || 'black';
-    this.fillWeight = opts.fillWeight || 0.85;
-    this.simplification = opts.simplification || 0.2;
+    this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
+    this.stroke = get(opts, 'stroke', 'black');
+    this.fillWeight = get(opts, 'fillWeight', 0.85);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.colors = opts.colors;
-    this.strokeWidth = opts.strokeWidth || 1;
+    this.strokeWidth = get(opts, 'strokeWidth', 1);
     this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '0.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.x = (this.dataFormat === 'object') ? 'x' : opts.x;
     this.y = (this.dataFormat === 'object') ? 'y' : opts.y;
     this.xValueFormat = opts.xValueFormat;
     this.yValueFormat = opts.yValueFormat;
-    this.xLabel = opts.xLabel || '';
-    this.yLabel = opts.yLabel || '';
-    this.labelFontSize = opts.labelFontSize || '1rem';
+    this.xLabel = get(opts, 'xLabel', '');
+    this.yLabel = get(opts, 'yLabel', '');
+    this.labelFontSize = get(opts, 'labelFontSize', '1rem');
     // new width
     this.initChartValues(opts);
     // resolve font
@@ -72,8 +69,8 @@ class Scatter {
       this.fontFamily = 'gaeguregular';
     } else if (
       this.font === 1 ||
-        this.font.toString().toLowerCase() === 'indie flower'
-    ){
+      this.font.toString().toLowerCase() === 'indie flower'
+    ) {
       addFontIndieFlower(this.svg);
       this.fontFamily = 'indie_flowerregular';
     } else {

--- a/src/StackedBar.js
+++ b/src/StackedBar.js
@@ -5,12 +5,9 @@ import { csv, tsv } from 'd3-fetch';
 import { scaleBand, scaleLinear, scaleOrdinal } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import { colors } from './utils/colors';
+import { roughCeiling } from './utils/roughCeiling';
 import rough from 'roughjs/dist/rough.umd';
-
-const roughCeiling = roughness => {
-  let roughVal = roughness > 20 ? 20 : roughness;
-  return roughVal;
-};
+import get from 'lodash.get';
 
 class StackedBar {
   constructor(opts) {
@@ -20,30 +17,30 @@ class StackedBar {
     this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 70, left: 100 };
     this.title = opts.title;
-    this.colors = opts.colors || colors;
-    this.highlight = opts.highlight || 'coral';
-    this.roughness = roughCeiling(opts.roughness) || 1;
-    this.stroke = opts.stroke || 'black';
-    this.strokeWidth = opts.strokeWidth || 1;
-    this.axisStrokeWidth = opts.axisStrokeWidth || 0.5;
-    this.axisRoughness = opts.axisRoughness || 0.5;
-    this.innerStrokeWidth = opts.innerStrokeWidth || 1;
+    this.colors = get(opts, 'colors', colors);
+    this.highlight = get(opts, 'highlight', 'coral');
+    this.roughness = roughCeiling({ roughness: opts.roughness });
+    this.stroke = get(opts, 'stroke', 'black');
+    this.strokeWidth = get(opts, 'strokeWidth', 1);
+    this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.5);
+    this.axisRoughness = get(opts, 'axisRoughness', 0.5);
+    this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
     this.fillStyle = opts.fillStyle;
-    this.bowing = opts.bowing || 0;
-    this.fillWeight = opts.fillWeight || 0.5;
-    this.simplification = opts.simplification || 0.2;
+    this.bowing = get(opts, 'bowing', 0);
+    this.fillWeight = get(opts, 'fillWeight', 0.5);
+    this.simplification = get(opts, 'simplification', 0.2);
     this.interactive = opts.interactive !== false;
     this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = opts.tooltipFontSize || '0.95rem';
-    this.font = opts.font || 0;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.font = get(opts, 'font', 0);
     this.dataFormat = typeof opts.data === 'object' ? 'object' : 'file';
     this.labels = opts.labels;
     this.values = opts.values;
-    this.padding = opts.padding || 0.1;
-    this.xLabel = opts.xLabel || '';
-    this.yLabel = opts.yLabel || '';
-    this.labelFontSize = opts.labelFontSize || '1rem';
+    this.padding = get(opts, 'padding', 0.1);
+    this.xLabel = get(opts, 'xLabel', '');
+    this.yLabel = get(opts, 'yLabel', '');
+    this.labelFontSize = get(opts, 'labelFontSize', '1rem');
     // new width
     this.initChartValues(opts);
     // resolve font
@@ -99,14 +96,14 @@ class StackedBar {
 
   // Helper Method to get the Total Value of the Stack
   getTotal(d){
-    for(let x = 0; x < d.length; x++){
+    for (let x = 0; x < d.length; x++) {
       let t = 0;
       for (let i = 0; i < d.columns.length; ++i) {
         if (d.columns[i] !== this.labels) {
           t += d[x][d.columns[i]] = +d[x][d.columns[i]];
         }
       }
-      d[x].total = t
+      d[x].total = t;
     }
     return d;
   }
@@ -142,7 +139,7 @@ class StackedBar {
               t += data[i][d];
               data[i].total = t;
             }
-          })
+          });
         }
         this.drawFromObject();
       };
@@ -310,18 +307,18 @@ class StackedBar {
   }
 
   addInteraction() {
-      selectAll(this.interactionG)
-        // .data(this.data)
-        // .append('rect')
-        .each(function(d, i){
-          let attr = this['attributes'];
-          select(this)
+    selectAll(this.interactionG)
+      // .data(this.data)
+      // .append('rect')
+      .each(function(d, i){
+        let attr = this['attributes'];
+        select(this)
           .append('rect')
           .attr('x', attr['x'].value)
           .attr('y', attr['y'].value)
           .attr('width', attr['width'].value)
           .attr('height', attr['height'].value)
-          .attr('fill', 'transparent')
+          .attr('fill', 'transparent');
       });
 
     // create tooltip
@@ -421,7 +418,7 @@ class StackedBar {
       let yStack = 0;
       keys.forEach((yValue, i) => {
         if (i > 0 && yValue !== 'total') {
-          yStack += parseInt(d[yValue]);
+          yStack += parseInt(d[yValue], 10);
           let x = this.xScale(d[this.labels]);
           let y = this.yScale(yStack);
           let width = this.xScale.bandwidth();
@@ -467,7 +464,7 @@ class StackedBar {
       .style('stroke-width', this.strokeWidth);
     // If desired, add interactivity
     if (this.interactive === true) {
-      this.addInteraction()
+      this.addInteraction();
     }
   } // draw
 
@@ -479,7 +476,7 @@ class StackedBar {
     this.addLabels();
     // Add Stackedbar
     this.stacking();
-    
+
     selectAll(this.interactionG)
       .selectAll('path:nth-child(2)')
       .style('stroke-width', this.strokeWidth);

--- a/src/utils/roughCeiling.js
+++ b/src/utils/roughCeiling.js
@@ -1,0 +1,14 @@
+const DEFAULT_CEILING = 20;
+const DEFAULT_VALUE = 1;
+
+const roughCeiling = ({ roughness, ceiling = DEFAULT_CEILING, defaultValue = DEFAULT_VALUE }) => {
+  if (roughness === undefined || typeof roughness !== 'number') return defaultValue;
+
+  return roughness > ceiling ? ceiling : roughness;
+};
+
+module.exports = {
+  roughCeiling,
+  DEFAULT_CEILING,
+  DEFAULT_VALUE,
+};

--- a/tests/utils/roughCeiling.test.js
+++ b/tests/utils/roughCeiling.test.js
@@ -1,0 +1,52 @@
+import { roughCeiling, DEFAULT_CEILING, DEFAULT_VALUE } from '../../src/utils/roughCeiling';
+
+describe('roughCeiling', () => {
+  test('Should return the value when below the default ceiling', () => {
+    const roughness = DEFAULT_CEILING - 4;
+    const result = roughCeiling({ roughness });
+
+    expect(result).toEqual(roughness);
+  });
+
+  test('Should return the default ceiling value when above the default ceiling', () => {
+    const roughness = DEFAULT_CEILING + 3;
+    const result = roughCeiling({ roughness });
+
+    expect(result).toEqual(DEFAULT_CEILING);
+  });
+
+  test('Should return the given ceiling when roughness value is above', () => {
+    const ceiling = 12;
+    const roughness = ceiling + 3;
+    const result = roughCeiling({ roughness, ceiling });
+
+    expect(result).toEqual(ceiling);
+  });
+
+  test('Should return the default value when no values are provided', () => {
+    const result = roughCeiling({});
+
+    expect(result).toEqual(DEFAULT_VALUE);
+  });
+
+  test('Should return the given default value when a roughness value is not provided', () => {
+    const defaultValue = 4;
+    const result = roughCeiling({ defaultValue });
+
+    expect(result).toEqual(defaultValue);
+  });
+
+  test('Should return the value when 0', () => {
+    const roughness = 0;
+    const result = roughCeiling({ roughness, ceiling: 25, defaultValue: 1 });
+
+    expect(result).toEqual(roughness);
+  });
+
+  test('Should return the default value when roughness is not a number', () => {
+    const roughness = '100';
+    const result = roughCeiling({ roughness, ceiling: 25 });
+
+    expect(result).toEqual(DEFAULT_VALUE);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,6 +2554,11 @@ d3-format@1:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.1.tgz#c45f74b17c5a290c072a4ba7039dd19662cd5ce6"
   integrity sha512-TUswGe6hfguUX1CtKxyG2nymO+1lyThbkS1ifLX0Sr+dOQtAD5gkrffpHnx+yHNKUZ0Bmg5T4AjUQwugPDrm0g==
 
+d3-format@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.2.tgz#2a8c0ebf500f315981c2110eaaf70b82f472cb2b"
+  integrity sha512-gco1Ih54PgMsyIXgttLxEhNy/mXxq8+rLnCb5shQk+P5TsiySrwWU5gpB4zen626J4LIwBxHvDChyA8qDm57ww==
+
 d3-interpolate@1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
@@ -4687,6 +4692,11 @@ lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
**Fixes issue**: #28 by using lodash.get.

**Also**:
- Refactor to use `roughCeiling()`, a  utility method which can be given an object of:
  - `{ roughness, ceiling, defaultValue }`
- Fixes the few minor lint issues