### PR TITLE
Create initial `Chart` super class that all inherit from.

### DIFF
--- a/src/Bar.js
+++ b/src/Bar.js
@@ -1,4 +1,4 @@
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
+
 import { max } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { csv, tsv } from 'd3-fetch';
@@ -7,16 +7,16 @@ import { scaleBand, scaleLinear } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import rough from 'roughjs/dist/rough.umd';
 import get from 'lodash.get';
+import Chart from './Chart';
 import { roughCeiling } from './utils/roughCeiling';
 
-class Bar {
+class Bar extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
     this.data = opts.data;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 70, left: 100 };
-    this.title = opts.title;
     this.color = get(opts, 'color', 'skyblue');
     this.highlight = get(opts, 'highlight', 'coral');
     this.roughness = roughCeiling({ roughness: opts.roughness });
@@ -25,16 +25,8 @@ class Bar {
     this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.5);
     this.axisRoughness = get(opts, 'axisRoughness', 0.5);
     this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.fillWeight = get(opts, 'fillWeight', 0.5);
-    this.simplification = get(opts, 'simplification', 0.2);
-    this.interactive = opts.interactive !== false;
-    this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.labels = (this.dataFormat === 'object') ? 'labels' : opts.labels;
     this.values = (this.dataFormat === 'object') ? 'values' : opts.values;
     this.xValueFormat = opts.xValueFormat;
@@ -62,36 +54,6 @@ class Bar {
     this.graphClass = this.el.substring(1, this.el.length);
     this.interactionG = 'g.' + this.graphClass;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr('transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')');
-  }
-
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
   }
 
   // add this to abstract base

--- a/src/BarH.js
+++ b/src/BarH.js
@@ -1,4 +1,3 @@
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
 import { max } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { csv, tsv } from 'd3-fetch';
@@ -7,16 +6,16 @@ import { scaleBand, scaleLinear } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import rough from 'roughjs/dist/rough.umd';
 import get from 'lodash.get';
+import Chart from './Chart';
 import { roughCeiling } from './utils/roughCeiling';
 
-class BarH {
+class BarH extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
     // this.data = opts.data;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 50, left: 100 };
-    this.title = opts.title;
     this.color = get(opts, 'color', 'skyblue');
     this.highlight = get(opts, 'highlight', 'coral');
     this.roughness = roughCeiling({ roughness: opts.roughness });
@@ -25,16 +24,8 @@ class BarH {
     this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.5);
     this.axisRoughness = get(opts, 'axisRoughness', 0.5);
     this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.fillWeight = get(opts, 'fillWeight', 0.5);
-    this.simplification = get(opts, 'simplification', 0.2);
-    this.interactive = opts.interactive !== false;
-    this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.labels = (this.dataFormat === 'object') ? 'labels' : opts.labels;
     this.values = (this.dataFormat === 'object') ? 'values' : opts.values;
     this.xValueFormat = opts.xValueFormat;
@@ -62,36 +53,6 @@ class BarH {
     this.graphClass = this.el.substring(1, this.el.length);
     this.interactionG = 'g.' + this.graphClass;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr('transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')');
-  }
-
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
   }
 
   // add this to abstract base

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,0 +1,50 @@
+import { select } from 'd3-selection';
+import get from 'lodash.get';
+import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
+
+class Chart {
+  constructor(opts) {
+    this.el = opts.element;
+    this.element = opts.element;
+    this.title = opts.title;
+    this.titleFontSize = opts.titleFontSize;
+    this.font = get(opts, 'font', 0);
+    this.fillStyle = opts.fillStyle;
+    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
+    this.bowing = get(opts, 'bowing', 0);
+    this.simplification = get(opts, 'simplification', 0.2);
+    this.interactive = opts.interactive !== false;
+    this.dataFormat = typeof opts.data === 'object' ? 'object' : 'file';
+  }
+
+  setSvg() {
+    this.svg = select(this.el)
+      .append('svg')
+      .attr('width', this.width + this.margin.left + this.margin.right)
+      .attr('height', this.height + this.margin.top + this.margin.bottom)
+      .append('g')
+      .attr('id', this.roughId)
+      .attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')');
+  }
+
+  resolveFont() {
+    if (
+      this.font === 0 ||
+      this.font === undefined ||
+      this.font.toString().toLowerCase() === 'gaegu'
+    ) {
+      addFontGaegu(this.svg);
+      this.fontFamily = 'gaeguregular';
+    } else if (
+      this.font === 1 ||
+      this.font.toString().toLowerCase() === 'indie flower'
+    ) {
+      addFontIndieFlower(this.svg);
+      this.fontFamily = 'indie_flowerregular';
+    } else {
+      this.fontFamily = this.font;
+    }
+  }
+}
+
+export default Chart;

--- a/src/Donut.js
+++ b/src/Donut.js
@@ -1,35 +1,26 @@
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
 import { csv, tsv, json } from 'd3-fetch';
 import { mouse, select, selectAll } from 'd3-selection';
 import { arc, pie } from 'd3-shape';
 import rough from 'roughjs/dist/rough.umd';
+import get from 'lodash.get';
+import Chart from './Chart';
 import { colors } from './utils/colors';
 import { addLegend } from './utils/addLegend';
 import { roughCeiling } from './utils/roughCeiling';
-import get from 'lodash.get';
 
-class Donut {
+class Donut extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
     // this.data = opts.data;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 10, left: 20 };
-    this.title = opts.title;
     this.colors = get(opts, 'colors', colors);
     this.highlight = opts.highlight;
     this.roughness = roughCeiling({ roughness: opts.roughness, ceiling: 30 });
     this.strokeWidth = get(opts, 'strokeWidth', 0.75);
     this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 0.75);
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.fillWeight = get(opts, 'fillWeight', 0.85);
-    this.simplification = get(opts, 'simplification', 0.2);
-    this.interactive = opts.interactive !== false;
-    this.titleFontSize = opts.titleFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = typeof opts.data === 'object' ? 'object' : 'file';
     this.labels = this.dataFormat === 'object' ? 'labels' : opts.labels;
     this.values = this.dataFormat === 'object' ? 'values' : opts.values;
     if (this.labels === undefined || this.values === undefined) {
@@ -59,38 +50,6 @@ class Donut {
     this.interactionG = 'g.' + this.graphClass;
     this.radius = Math.min(this.width, this.height) / 2;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr(
-        'transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')'
-      );
-  }
-
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
   }
 
   // add this to abstract base

--- a/src/Line.js
+++ b/src/Line.js
@@ -2,15 +2,15 @@ import { bisect, extent, max, min, range } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { csv, tsv } from 'd3-fetch';
 import { format } from 'd3-format';
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
-import { addLegend } from './utils/addLegend';
 import { scaleLinear, scalePoint } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import { line } from 'd3-shape';
 import rough from 'roughjs/dist/rough.umd';
+import get from 'lodash.get';
+import Chart from './Chart';
+import { addLegend } from './utils/addLegend';
 import { colors } from './utils/colors';
 import { roughCeiling } from './utils/roughCeiling';
-import get from 'lodash.get';
 
 const allDataExtent = (data) => {
   // get extend for all keys in data
@@ -21,29 +21,20 @@ const allDataExtent = (data) => {
   return [dataMin, dataMax];
 };
 
-class Line {
+class Line extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 50, left: 100 };
-    this.title = opts.title;
     this.roughness = roughCeiling({ roughness: opts.roughness, defaultValue: 2.2 });
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.4);
     this.axisRoughness = get(opts, 'axisRoughness', 0.9);
-    this.interactive = opts.interactive !== false;
     this.stroke = get(opts, 'stroke', 'black');
     this.fillWeight = get(opts, 'fillWeight', 0.85);
-    this.simplification = get(opts, 'simplification', 0.2);
     this.colors = opts.colors;
     this.strokeWidth = get(opts, 'strokeWidth', 8);
-    this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.x = opts.x;
     this.y = (this.dataFormat === 'object') ? 'y' : opts.y;
     this.xValueFormat = opts.xValueFormat;
@@ -73,25 +64,6 @@ class Line {
     if (opts.title !== 'undefined') this.setTitle(opts.title);
   }
 
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
-  }
-
   initChartValues(opts) {
     let width = opts.width ? opts.width : 300;
     let height = opts.height ? opts.height : 400;
@@ -101,17 +73,6 @@ class Line {
     this.graphClass = this.el.substring(1, this.el.length);
     this.interactionG = 'g.' + this.graphClass;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr('transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')');
   }
 
   // add this to abstract base

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -1,35 +1,26 @@
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
 import { csv, tsv, json } from 'd3-fetch';
 import { mouse, select, selectAll } from 'd3-selection';
 import { arc, pie } from 'd3-shape';
 import rough from 'roughjs/dist/rough.umd';
+import get from 'lodash.get';
+import Chart from './Chart';
 import { colors } from './utils/colors';
 import { addLegend } from './utils/addLegend';
 import { roughCeiling } from './utils/roughCeiling';
-import get from 'lodash.get';
 
-class Pie {
+class Pie extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
     // this.data = opts.data;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 10, left: 20 };
-    this.title = opts.title;
     this.colors = get(opts, 'colors', colors);
     this.highlight = opts.highlight;
     this.roughness = roughCeiling({ roughness: opts.roughness, ceiling: 30, defaultValue: 0 });
     this.strokeWidth = get(opts, 'strokeWidth', 0.75);
     this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.fillWeight = get(opts, 'fillWeight', 0.5);
-    this.simplification = get(opts, 'simplification', 0.2);
-    this.interactive = opts.interactive !== false;
-    this.titleFontSize = opts.titleFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.labels = (this.dataFormat === 'object') ? 'labels' : opts.labels;
     this.values = (this.dataFormat === 'object') ? 'values' : opts.values;
     if (this.labels === undefined || this.values === undefined) {
@@ -59,36 +50,6 @@ class Pie {
     this.interactionG = 'g.' + this.graphClass;
     this.radius = Math.min(this.width, this.height) / 2;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr('transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')');
-  }
-
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
   }
 
   // add this to abstract base

--- a/src/Scatter.js
+++ b/src/Scatter.js
@@ -2,46 +2,37 @@ import { extent } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { csv, tsv } from 'd3-fetch';
 import { format } from 'd3-format';
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
-import { roughCeiling } from './utils/roughCeiling';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
 import rough from 'roughjs/dist/rough.umd';
 import get from 'lodash.get';
+import Chart from './Chart';
+import { roughCeiling } from './utils/roughCeiling';
 
 const defaultColors = ['pink', 'skyblue', 'coral', 'gold', 'teal', 'grey',
   'darkgreen', 'pink', 'brown', 'slateblue', 'grey1', 'orange'];
 
-class Scatter {
+class Scatter extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
     // this.data = opts.data;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 50, left: 100 };
-    this.title = opts.title;
     this.colorVar = opts.colorVar;
     this.roughness = roughCeiling({ roughness: opts.roughness });
     this.highlight = opts.highlight;
     this.highlightLabel = get(opts, 'highlightLabel', 'xy');
     this.radius = get(opts, 'radius', 8);
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.4);
     this.axisRoughness = get(opts, 'axisRoughness', 0.9);
-    this.interactive = opts.interactive !== false;
     this.curbZero = opts.curbZero === true;
     this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
     this.stroke = get(opts, 'stroke', 'black');
     this.fillWeight = get(opts, 'fillWeight', 0.85);
-    this.simplification = get(opts, 'simplification', 0.2);
     this.colors = opts.colors;
     this.strokeWidth = get(opts, 'strokeWidth', 1);
-    this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = (typeof opts.data === 'object') ? 'object' : 'file';
     this.x = (this.dataFormat === 'object') ? 'x' : opts.x;
     this.y = (this.dataFormat === 'object') ? 'y' : opts.y;
     this.xValueFormat = opts.xValueFormat;
@@ -59,25 +50,6 @@ class Scatter {
     if (opts.title !== 'undefined') this.setTitle(opts.title);
   }
 
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
-  }
-
   initChartValues(opts) {
     let width = opts.width ? opts.width : 300;
     let height = opts.height ? opts.height : 400;
@@ -87,17 +59,6 @@ class Scatter {
     this.graphClass = this.el.substring(1, this.el.length);
     this.interactionG = 'g.' + this.graphClass;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr('transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')');
   }
 
   // add this to abstract base

--- a/src/StackedBar.js
+++ b/src/StackedBar.js
@@ -1,22 +1,21 @@
-import { addFontGaegu, addFontIndieFlower } from './utils/addFonts';
 import { max } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { csv, tsv } from 'd3-fetch';
 import { scaleBand, scaleLinear, scaleOrdinal } from 'd3-scale';
 import { mouse, select, selectAll } from 'd3-selection';
-import { colors } from './utils/colors';
-import { roughCeiling } from './utils/roughCeiling';
 import rough from 'roughjs/dist/rough.umd';
 import get from 'lodash.get';
+import Chart from './Chart';
+import { colors } from './utils/colors';
+import { roughCeiling } from './utils/roughCeiling';
 
-class StackedBar {
+class StackedBar extends Chart {
   constructor(opts) {
+    super(opts);
+
     // load in arguments from config object
-    this.el = opts.element;
     this.data = opts.data;
-    this.element = opts.element;
     this.margin = opts.margin || { top: 50, right: 20, bottom: 70, left: 100 };
-    this.title = opts.title;
     this.colors = get(opts, 'colors', colors);
     this.highlight = get(opts, 'highlight', 'coral');
     this.roughness = roughCeiling({ roughness: opts.roughness });
@@ -25,16 +24,8 @@ class StackedBar {
     this.axisStrokeWidth = get(opts, 'axisStrokeWidth', 0.5);
     this.axisRoughness = get(opts, 'axisRoughness', 0.5);
     this.innerStrokeWidth = get(opts, 'innerStrokeWidth', 1);
-    this.fillStyle = opts.fillStyle;
-    this.bowing = get(opts, 'bowing', 0);
     this.fillWeight = get(opts, 'fillWeight', 0.5);
-    this.simplification = get(opts, 'simplification', 0.2);
-    this.interactive = opts.interactive !== false;
-    this.titleFontSize = opts.titleFontSize;
     this.axisFontSize = opts.axisFontSize;
-    this.tooltipFontSize = get(opts, 'tooltipFontSize', '0.95rem');
-    this.font = get(opts, 'font', 0);
-    this.dataFormat = typeof opts.data === 'object' ? 'object' : 'file';
     this.labels = opts.labels;
     this.values = opts.values;
     this.stackColorMapping = {};
@@ -61,38 +52,6 @@ class StackedBar {
     this.graphClass = this.el.substring(1, this.el.length);
     this.interactionG = 'g.' + this.graphClass;
     this.setSvg();
-  }
-
-  setSvg() {
-    this.svg = select(this.el)
-      .append('svg')
-      .attr('width', this.width + this.margin.left + this.margin.right)
-      .attr('height', this.height + this.margin.top + this.margin.bottom)
-      .append('g')
-      .attr('id', this.roughId)
-      .attr(
-        'transform',
-        'translate(' + this.margin.left + ',' + this.margin.top + ')'
-      );
-  }
-
-  resolveFont() {
-    if (
-      this.font === 0 ||
-      this.font === undefined ||
-      this.font.toString().toLowerCase() === 'gaegu'
-    ) {
-      addFontGaegu(this.svg);
-      this.fontFamily = 'gaeguregular';
-    } else if (
-      this.font === 1 ||
-      this.font.toString().toLowerCase() === 'indie flower'
-    ) {
-      addFontIndieFlower(this.svg);
-      this.fontFamily = 'indie_flowerregular';
-    } else {
-      this.fontFamily = this.font;
-    }
   }
 
   // Helper Method to get the Total Value of the Stack


### PR DESCRIPTION
Relates to: #31 

Instead of trying to refactor this all in one go (like the attempt in #32), I have just created the initial `Chart` super class and then moved all the common functionality over... only everything that's 100% the same.

After this PR we can start refactoring the remaining similar, but slightly different methods.

---

So far only the following methods have been moved across:

- `setSvg`
- `resolveFont`

Along with 11 duplicated class properties.

---

The remaining methods to be moved across are:

- `initChartValues `
- `resolveData `
- `setTitle `

I'm thinking the 2 charts that require a radius to be set in `initChartValues` could be inherited from another super class because they probably share more (that I've not seen yet), and I don't want to make the base `Chart` class too complicated with lots of configuration.


Also, if we choose a standard height/width for all charts that will make the refactored `initChartValues` method less complex and more readable.

What do you think @jwilber ?