### PR TITLE
Use input event for color pickers

### DIFF
--- a/website/roughDemo.js
+++ b/website/roughDemo.js
@@ -575,8 +575,8 @@ innerStrokeWidthSlider.addEventListener("change", updateChart);
 fillWeightSlider.addEventListener("change", updateChart);
 axisRoughnessSlider.addEventListener("change", updateChart);
 
-colorSlider.addEventListener("change", updateChart);
-strokeSlider.addEventListener("change", updateChart);
+colorSlider.addEventListener("input", updateChart);
+strokeSlider.addEventListener("input", updateChart);
 
 document.querySelectorAll(".menuItem").forEach((item) => {
   item.addEventListener("click", (event) => {


### PR DESCRIPTION
Currently, stroke and color inputs are updated `onchange` aka when color UI box is dismissed (very annoying). 

Proposing to use `oninput` so that updateChart is fired every time new color is selected